### PR TITLE
Fixes preloading logic in GA and Twitter Pixel

### DIFF
--- a/src/google-adwords.js
+++ b/src/google-adwords.js
@@ -3,7 +3,7 @@ import loadScript from './script-loader.js';
 export default function configureGoogleAdWords({ config, handlers, window, document }) {
   let promise = Promise.resolve();
 
-  if (config.preloaded) {
+  if (!config.preloaded) {
     const src = 'https://www.googleadservices.com/pagead/conversion_async.js';
     promise = loadScript({ src, globalName: 'google_trackConversion', stubType: 'function', window, document });
   }

--- a/src/google-analytics.js
+++ b/src/google-analytics.js
@@ -3,7 +3,7 @@ import loadScript from './script-loader.js';
 export default function configureGoogleAnalitycs({ config, handlers, window, document }) {
   let promise = Promise.resolve();
 
-  if (config.preloaded) {
+  if (!config.preloaded) {
     const src = 'https://www.google-analytics.com/analytics.js';
     const stub = function () {
       stub.q.push(arguments);

--- a/src/twitter-ads-pixel.js
+++ b/src/twitter-ads-pixel.js
@@ -3,7 +3,7 @@ import loadScript from './script-loader.js';
 export default function configureTwitterAdsPixel({ config, handlers, window, document }) {
   let promise = Promise.resolve();
 
-  if (config.preloaded) {
+  if (!config.preloaded) {
     const src = 'https://static.ads-twitter.com/uwt.js';
     const stub = function () {
       stub.exe ? stub.exe.apply(stub, arguments) : stub.queue.push(arguments);


### PR DESCRIPTION
The current release does not match documentation. If the flag `preloaded` is set to `true` as per documentation Google Analytics is loaded a second time with an undefined id. Logic corrected.